### PR TITLE
feat(gitlab): Add support for parsing GitLab remote urls

### DIFF
--- a/docs/supported-urls.md
+++ b/docs/supported-urls.md
@@ -9,3 +9,13 @@
   - Examples
     - `https://github.com/ap0llo/semantic-url-parser.git`
     - `git@github.com:ap0llo/semantic-url-parser.git`
+
+
+## GitLab
+
+- Remote Url
+  - Parses git remote urls for repositories hosted on GitLab
+  - Retrieves the Host, Namespace (user or group/subgroup) and the project name
+  - Examples
+    - `https://gitlab.com/user/project.git`
+    - `git@gitlab.com:group/subgroup/project.git`

--- a/src/SemanticUrlParser.Test/GitHub/GitHubUrlParserTest.RemoteUrl.cs
+++ b/src/SemanticUrlParser.Test/GitHub/GitHubUrlParserTest.RemoteUrl.cs
@@ -23,11 +23,17 @@ namespace Grynwald.SemanticUrlParser.Test.GitHub
             // invalid URIs
             yield return TestCase("not-a-url");
 
+            // unsupported scheme
+            yield return TestCase("ftp://github.com/owner/repo.git");
+
             // to many segments in the path
             yield return TestCase("http://github.com/owner/another-name/repo.git");
 
-            // unsupported scheme
-            yield return TestCase("ftp://github.com/owner/repo.git");
+            // empty or whitespace project path
+            yield return TestCase("http://github.com/");
+            yield return TestCase("http://github.com/ ");
+            yield return TestCase("http://github.com/.git");
+            yield return TestCase("http://github.com/ .git");
 
             // empty or whitespace owner
             yield return TestCase("http://github.com//repo.git");

--- a/src/SemanticUrlParser.Test/GitLab/GitLabProjectInfoTest.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabProjectInfoTest.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using Grynwald.SemanticUrlParser.GitLab;
+using Xunit;
+
+namespace Grynwald.SemanticUrlParser.Test.GitLab
+{
+    /// <summary>
+    /// Tests for <see cref="GitLabProjectInfo"/>
+    /// </summary>
+    public class GitLabProjectInfoTest : EqualityTest<GitLabProjectInfo, GitLabProjectInfoTest>, IEqualityTestDataProvider<GitLabProjectInfo>
+    {
+        public IEnumerable<(GitLabProjectInfo left, GitLabProjectInfo right)> GetEqualTestCases()
+        {
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "user", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo")
+            );
+
+            // Comparisons must be case-insensitive
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("EXAMPLE.COM", "user", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("EXAMPLE.COM", "group/subgroup", "repo")
+            );
+
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "USER", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "GROUP/SUBGROUP", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "user", "REPO")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/subgroup", "REPO")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/SUBGROUP", "repo")
+            );
+
+            // Leading and trailing slahes in namespace and project are ignored
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "/user", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "/group/subgroup", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "user/", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/subgroup/", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "user", "/repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/subgroup", "/repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.com", "user", "repo/")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo/")
+            );
+        }
+
+        public IEnumerable<(GitLabProjectInfo left, GitLabProjectInfo right)> GetUnequalTestCases()
+        {
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo"),
+                new GitLabProjectInfo("example.net", "user", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo"),
+                new GitLabProjectInfo("example.net", "group/subgroup", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user1", "repo"),
+                new GitLabProjectInfo("example.com", "user2", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group1/subgroup", "repo"),
+                new GitLabProjectInfo("example.com", "group2/subgroup", "repo")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "user", "repo1"),
+                new GitLabProjectInfo("example.com", "user", "repo2")
+            );
+            yield return (
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo1"),
+                new GitLabProjectInfo("example.com", "group/subgroup", "repo2")
+            );
+        }
+
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        public void Host_must_not_be_null_or_whitespace(string host)
+        {
+            Assert.Throws<ArgumentException>(() => new GitLabProjectInfo(host, "user", "repo"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        public void Namespace_must_not_be_null_or_whitespace(string @namespace)
+        {
+            Assert.Throws<ArgumentException>(() => new GitLabProjectInfo("example.com", @namespace, "repo"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        public void Project_must_not_be_null_or_whitespace(string project)
+        {
+            Assert.Throws<ArgumentException>(() => new GitLabProjectInfo("example.com", "user", project));
+        }
+    }
+}

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Grynwald.SemanticUrlParser.GitLab;
+using Xunit;
+
+namespace Grynwald.SemanticUrlParser.Test.GitLab
+{
+    public partial class GitLabUrlParserTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
+        public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
+        {
+            var sut = new GitLabUrlParser();
+            Assert.ThrowsAny<ArgumentException>(() => sut.ParseRemoteUrl(url));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string @namespace, string proejctName)
+        {
+            // ARRANGE
+            var sut = new GitLabUrlParser();
+            var expected = new GitLabProjectInfo(host, @namespace, proejctName);
+
+            // ACT
+            var actual = sut.ParseRemoteUrl(remoteUrl);
+
+            // ASSERT
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
+        public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
+        {
+            var sut = new GitLabUrlParser();
+            Assert.False(sut.TryParseRemoteUrl(url, out var uri));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string @namespace, string projectName)
+        {
+            // ARRANGE
+            var expected = new GitLabProjectInfo(host, @namespace, projectName);
+            var sut = new GitLabUrlParser();
+
+            // ACT 
+            var success = sut.TryParseRemoteUrl(url, out var projectInfo);
+
+            // ASSERT
+            Assert.True(success);
+            Assert.Equal(expected, projectInfo);
+        }
+    }
+}

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
@@ -12,9 +12,12 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("ftp://gitlab.com/user/repo.git")]  // unsupported scheme
         [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user")]          // missing project name
+        [InlineData("http://gitlab.com/user/repo")]     // missing .git suffix
+        [InlineData("http://gitlab.com/user")]          // missing project name and .git suffix
+        [InlineData("http://gitlab.com/user/.git")]     // missing project name
+        [InlineData("http://gitlab.com//repo.git")]     // missing namespace
         public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
         {
             var sut = new GitLabUrlParser();
@@ -48,9 +51,12 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
         [InlineData("\t")]
         [InlineData("  ")]
         [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("ftp://gitlab.com/user/repo.git")]  // unsupported scheme
         [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user")]          // missing project name
+        [InlineData("http://gitlab.com/user/repo")]     // missing .git suffix
+        [InlineData("http://gitlab.com/user")]          // missing project name and .git suffix
+        [InlineData("http://gitlab.com/user/.git")]     // missing project name
+        [InlineData("http://gitlab.com//repo.git")]     // missing namespace
         public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
         {
             var sut = new GitLabUrlParser();

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Grynwald.SemanticUrlParser.GitLab;
 using Xunit;
 
@@ -6,18 +7,48 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
 {
     public partial class GitLabUrlParserTest
     {
+        public static IEnumerable<object?[]> NegativeTestCases()
+        {
+            static object?[] TestCase(string? url)
+            {
+                return new object?[] { url };
+            }
+
+            yield return TestCase(null);
+            yield return TestCase("");
+            yield return TestCase("\t");
+            yield return TestCase("  ");
+            yield return TestCase("not-a-url");
+            yield return TestCase("ftp://gitlab.com/user/repo.git");  // unsupported scheme
+            yield return TestCase("http://gitlab.com");               // missing project path
+            yield return TestCase("http://gitlab.com/user/repo");     // missing .git suffix
+            yield return TestCase("http://gitlab.com/user");          // missing project name and .git suffix
+            yield return TestCase("http://gitlab.com/user/.git");     // missing project name
+            yield return TestCase("http://gitlab.com//repo.git");     // missing namespace
+        }
+
+        public static IEnumerable<object?[]> PositiveTestCases()
+        {
+            static object?[] TestCase(string url, string host, string @namespace, string projectName)
+            {
+                return new object?[] { url, host, @namespace, projectName };
+            }
+
+            yield return TestCase("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame");
+            yield return TestCase("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame");
+            yield return TestCase("https://example.com/user/repoName.git", "example.com", "user", "reponame");
+            yield return TestCase("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName");
+            yield return TestCase("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName");
+            yield return TestCase("git@example.com:user/repoName.git", "example.com", "user", "repoName");
+            yield return TestCase("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName");
+
+
+
+        }
+
+
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/user/repo.git")]  // unsupported scheme
-        [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user/repo")]     // missing .git suffix
-        [InlineData("http://gitlab.com/user")]          // missing project name and .git suffix
-        [InlineData("http://gitlab.com/user/.git")]     // missing project name
-        [InlineData("http://gitlab.com//repo.git")]     // missing namespace
+        [MemberData(nameof(NegativeTestCases))]
         public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
         {
             var sut = new GitLabUrlParser();
@@ -25,52 +56,31 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
         }
 
         [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
-        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string @namespace, string proejctName)
+        [MemberData(nameof(PositiveTestCases))]
+        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string url, string host, string @namespace, string projectName)
         {
             // ARRANGE
             var sut = new GitLabUrlParser();
-            var expected = new GitLabProjectInfo(host, @namespace, proejctName);
+            var expected = new GitLabProjectInfo(host, @namespace, projectName);
 
             // ACT
-            var actual = sut.ParseRemoteUrl(remoteUrl);
+            var actual = sut.ParseRemoteUrl(url);
 
             // ASSERT
             Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/user/repo.git")]  // unsupported scheme
-        [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user/repo")]     // missing .git suffix
-        [InlineData("http://gitlab.com/user")]          // missing project name and .git suffix
-        [InlineData("http://gitlab.com/user/.git")]     // missing project name
-        [InlineData("http://gitlab.com//repo.git")]     // missing namespace
+        [MemberData(nameof(NegativeTestCases))]
         public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
         {
             var sut = new GitLabUrlParser();
             Assert.False(sut.TryParseRemoteUrl(url, out var uri));
+            Assert.Null(uri);
         }
 
         [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        [MemberData(nameof(PositiveTestCases))]
         public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string @namespace, string projectName)
         {
             // ARRANGE

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.RemoteUrl.cs
@@ -14,17 +14,40 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
                 return new object?[] { url };
             }
 
+            // null or whitespace urls
             yield return TestCase(null);
             yield return TestCase("");
             yield return TestCase("\t");
             yield return TestCase("  ");
+
+            // invalid URIs
             yield return TestCase("not-a-url");
-            yield return TestCase("ftp://gitlab.com/user/repo.git");  // unsupported scheme
-            yield return TestCase("http://gitlab.com");               // missing project path
-            yield return TestCase("http://gitlab.com/user/repo");     // missing .git suffix
-            yield return TestCase("http://gitlab.com/user");          // missing project name and .git suffix
-            yield return TestCase("http://gitlab.com/user/.git");     // missing project name
-            yield return TestCase("http://gitlab.com//repo.git");     // missing namespace
+
+            // unsupported scheme
+            yield return TestCase("ftp://gitlab.com/user/repo.git");
+
+            // missing project path
+            yield return TestCase("http://gitlab.com");
+
+            // missing .git suffix
+            yield return TestCase("http://gitlab.com/user/repo");
+
+            // missing project name and .git suffix
+            yield return TestCase("http://gitlab.com/user");
+
+            // empty or whitespace project path
+            yield return TestCase("http://gitlab.com/");
+            yield return TestCase("http://gitlab.com/.git");
+            yield return TestCase("http://gitlab.com/ ");
+            yield return TestCase("http://gitlab.com/ .git");
+
+            // empty or whitespace namespace
+            yield return TestCase("http://gitlab.com//repo.git");
+            yield return TestCase("http://gitlab.com/ /repo.git");
+
+            // empty of whitespace name
+            yield return TestCase("http://gitlab.com/user/.git");
+            yield return TestCase("http://gitlab.com/user/ .git");
         }
 
         public static IEnumerable<object?[]> PositiveTestCases()
@@ -35,15 +58,19 @@ namespace Grynwald.SemanticUrlParser.Test.GitLab
             }
 
             yield return TestCase("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame");
+            yield return TestCase("https://gitlab.com/user/repoName.GIT", "gitlab.com", "user", "reponame");
             yield return TestCase("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame");
+            yield return TestCase("https://gitlab.com/group/subgroup/repoName.GIT", "gitlab.com", "group/subgroup", "reponame");
             yield return TestCase("https://example.com/user/repoName.git", "example.com", "user", "reponame");
+            yield return TestCase("https://example.com/user/repoName.GIT", "example.com", "user", "reponame");
             yield return TestCase("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName");
+            yield return TestCase("git@gitlab.com:user/repoName.GIT", "gitlab.com", "user", "repoName");
             yield return TestCase("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName");
+            yield return TestCase("git@gitlab.com:group/subgroup/repoName.GIT", "gitlab.com", "group/subgroup", "repoName");
             yield return TestCase("git@example.com:user/repoName.git", "example.com", "user", "repoName");
+            yield return TestCase("git@example.com:user/repoName.GIT", "example.com", "user", "repoName");
             yield return TestCase("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName");
-
-
-
+            yield return TestCase("git@example.com:group/subgroup/repoName.GIT", "example.com", "group/subgroup", "repoName");
         }
 
 

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Grynwald.SemanticUrlParser.GitLab;
+using Grynwald.SemanticUrlParser.GitLab.GitLab;
+using Xunit;
+
+namespace Grynwald.SemanticUrlParser.Test.GitLab
+{
+    /// <summary>
+    /// Unit tests for <see cref="GitLabUrlParser"/>
+    /// </summary>
+    public class GitLabUrlParserTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
+        public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => GitLabUrlParser.ParseRemoteUrl(url));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string @namespace, string proejctName)
+        {
+            // ARRANGE
+            var expected = new GitLabProjectInfo(host, @namespace, proejctName);
+
+            // ACT
+            var actual = GitLabUrlParser.ParseRemoteUrl(remoteUrl);
+
+            // ASSERT
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("\t")]
+        [InlineData("  ")]
+        [InlineData("not-a-url")]
+        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
+        [InlineData("http://gitlab.com")]               // missing project path
+        [InlineData("http://gitlab.com/user")]          // missing project name
+        public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
+        {
+            Assert.False(GitLabUrlParser.TryParseRemoteUrl(url, out var uri));
+        }
+
+        [Theory]
+        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
+        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
+        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
+        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
+        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
+        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
+        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
+        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string @namespace, string projectName)
+        {
+            // ARRANGE
+            var expected = new GitLabProjectInfo(host, @namespace, projectName);
+            // ACT 
+            var success = GitLabUrlParser.TryParseRemoteUrl(url, out var projectInfo);
+
+            // ASSERT
+            Assert.True(success);
+            Assert.Equal(expected, projectInfo);
+        }
+    }
+}

--- a/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.cs
+++ b/src/SemanticUrlParser.Test/GitLab/GitLabUrlParserTest.cs
@@ -1,81 +1,11 @@
-﻿using System;
-using Grynwald.SemanticUrlParser.GitLab;
-using Grynwald.SemanticUrlParser.GitLab.GitLab;
-using Xunit;
+﻿using Grynwald.SemanticUrlParser.GitLab;
 
 namespace Grynwald.SemanticUrlParser.Test.GitLab
 {
     /// <summary>
     /// Unit tests for <see cref="GitLabUrlParser"/>
     /// </summary>
-    public class GitLabUrlParserTest
+    public partial class GitLabUrlParserTest
     {
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
-        [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user")]          // missing project name
-        public void ParseRemoteUrl_throws_ArgumentException_for_invalid_input(string url)
-        {
-            Assert.ThrowsAny<ArgumentException>(() => GitLabUrlParser.ParseRemoteUrl(url));
-        }
-
-        [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
-        public void ParseRemoteUrl_returns_the_expected_GitLabProjectInfo(string remoteUrl, string host, string @namespace, string proejctName)
-        {
-            // ARRANGE
-            var expected = new GitLabProjectInfo(host, @namespace, proejctName);
-
-            // ACT
-            var actual = GitLabUrlParser.ParseRemoteUrl(remoteUrl);
-
-            // ASSERT
-            Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("\t")]
-        [InlineData("  ")]
-        [InlineData("not-a-url")]
-        [InlineData("ftp://gitlab.com/owner/repo.git")] // unsupported scheme
-        [InlineData("http://gitlab.com")]               // missing project path
-        [InlineData("http://gitlab.com/user")]          // missing project name
-        public void TryParseRemoteUrl_returns_false_for_invalid_input(string url)
-        {
-            Assert.False(GitLabUrlParser.TryParseRemoteUrl(url, out var uri));
-        }
-
-        [Theory]
-        [InlineData("https://gitlab.com/user/repoName.git", "gitlab.com", "user", "reponame")]
-        [InlineData("https://gitlab.com/group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "reponame")]
-        [InlineData("https://example.com/user/repoName.git", "example.com", "user", "reponame")]
-        [InlineData("git@gitlab.com:user/repoName.git", "gitlab.com", "user", "repoName")]
-        [InlineData("git@gitlab.com:group/subgroup/repoName.git", "gitlab.com", "group/subgroup", "repoName")]
-        [InlineData("git@example.com:user/repoName.git", "example.com", "user", "repoName")]
-        [InlineData("git@example.com:group/subgroup/repoName.git", "example.com", "group/subgroup", "repoName")]
-        public void TryParseRemoteUrl_returns_the_expected_GitHubProjectInfo(string url, string host, string @namespace, string projectName)
-        {
-            // ARRANGE
-            var expected = new GitLabProjectInfo(host, @namespace, projectName);
-            // ACT 
-            var success = GitLabUrlParser.TryParseRemoteUrl(url, out var projectInfo);
-
-            // ASSERT
-            Assert.True(success);
-            Assert.Equal(expected, projectInfo);
-        }
     }
 }

--- a/src/SemanticUrlParser/GitLab/GitLabProjectInfo.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabProjectInfo.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Grynwald.SemanticUrlParser.GitLab
+{
+    public sealed class GitLabProjectInfo : IEquatable<GitLabProjectInfo>
+    {
+        /// <summary>
+        /// The host name of the GitLab server.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// The project namespace (the user or group (incl.subgroups) the project belongs to
+        /// </summary>
+        public string Namespace { get; }
+
+        /// <summary>
+        /// The project name
+        /// </summary>
+        public string Project { get; }
+
+        /// <summary>
+        /// The GitLab project path (i.e. namespace + repository name).
+        /// </summary>
+        public string ProjectPath => $"{Namespace}/{Project}";
+
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="GitLabProjectInfo"/>
+        /// </summary>
+        /// <param name="host">The host name of the GitLab server.</param>
+        /// <param name="projectPath">The GitLab project path (i.e. namespace + repository name).</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="host"/> or <paramref name="projectPath"/> is null or whitespace</exception>
+        public GitLabProjectInfo(string host, string @namespace, string project)
+        {
+            if (String.IsNullOrWhiteSpace(host))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(host));
+
+            if (String.IsNullOrWhiteSpace(@namespace))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(@namespace));
+
+            if (String.IsNullOrWhiteSpace(project))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(project));
+
+            Host = host;
+            Namespace = @namespace.Trim('/');
+            Project = project.Trim('/');
+        }
+
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as GitLabProjectInfo);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = StringComparer.OrdinalIgnoreCase.GetHashCode(Host) * 397;
+                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(Namespace);
+                hash ^= StringComparer.OrdinalIgnoreCase.GetHashCode(Project);
+                return hash;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool Equals([AllowNull] GitLabProjectInfo other)
+        {
+            return other != null &&
+                StringComparer.OrdinalIgnoreCase.Equals(Host, other.Host) &&
+                StringComparer.OrdinalIgnoreCase.Equals(Namespace, other.Namespace) &&
+                StringComparer.OrdinalIgnoreCase.Equals(Project, other.Project);
+        }
+    }
+}

--- a/src/SemanticUrlParser/GitLab/GitLabProjectInfo.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabProjectInfo.cs
@@ -3,6 +3,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Grynwald.SemanticUrlParser.GitLab
 {
+    /// <summary>
+    /// Encapsulates information about a GitLab project.
+    /// </summary>
     public sealed class GitLabProjectInfo : IEquatable<GitLabProjectInfo>
     {
         /// <summary>
@@ -11,17 +14,17 @@ namespace Grynwald.SemanticUrlParser.GitLab
         public string Host { get; }
 
         /// <summary>
-        /// The project namespace (the user or group (incl.subgroups) the project belongs to
+        /// The project namespace (the user or group (incl.subgroups)) the project belongs to
         /// </summary>
         public string Namespace { get; }
 
         /// <summary>
-        /// The project name
+        /// The project name.
         /// </summary>
         public string Project { get; }
 
         /// <summary>
-        /// The GitLab project path (i.e. namespace + repository name).
+        /// The GitLab project path (= namespace + repository name).
         /// </summary>
         public string ProjectPath => $"{Namespace}/{Project}";
 

--- a/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
@@ -58,16 +58,15 @@ namespace Grynwald.SemanticUrlParser.GitLab
                 case "http":
                 case "https":
                 case "ssh":
-                    var projectPath = uri.AbsolutePath.Trim('/');
+                    var projectPath = Uri.UnescapeDataString(uri.AbsolutePath).Trim('/');
 
-                    if (!projectPath.EndsWith(".git"))
+                    if (!projectPath.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
                     {
                         errorMessage = $"Cannot parse '{url}' as GitLab url: Expected url to end with '.git'";
                         return false;
-
                     }
 
-                    projectPath = projectPath.RemoveSuffix(".git");
+                    projectPath = projectPath.RemoveSuffix(".git", StringComparison.OrdinalIgnoreCase);
 
                     if (String.IsNullOrWhiteSpace(projectPath))
                     {

--- a/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Grynwald.SemanticUrlParser.Utilities;
+
+namespace Grynwald.SemanticUrlParser.GitLab
+{
+    public partial class GitLabUrlParser
+    {
+        /// <summary>
+        /// Parses the specified git remote url.
+        /// Supports both HTTP and SSH urls.
+        /// </summary>
+        /// <param name="url">The url to parse.</param>
+        /// <returns>Returns a <see cref="GitLabProjectInfo"/> with information about the GitLab project the remote url belongs to.</returns>
+        /// <exception cref="ArgumentException">Thrown if the specified url could not be parsed.</exception>
+        public GitLabProjectInfo ParseRemoteUrl(string url)
+        {
+            if (TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
+            {
+                return projectInfo;
+            }
+            else
+            {
+                throw new ArgumentException(errorMessage, nameof(url));
+            }
+        }
+
+        /// <summary>
+        /// Attempts to parse the specified git remote url.
+        /// Supports both HTTP and SSH urls.
+        /// </summary>
+        /// <param name="url">The url to parse.</param>
+        /// <param name="projectInfo">When successful, contains a <see cref="GitLabProjectInfo"/> with information about the GitLab project the remote url belongs to.</param>
+        /// <returns>Returns <c>true</c> if the specified url could be parsed, otherwise returns <c>false</c>.</returns>
+        public bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo) =>
+            TryParseRemoteUrl(url, out projectInfo, out var _);
+
+
+        private static bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo, [NotNullWhen(false)] out string? errorMessage)
+        {
+            projectInfo = null;
+            errorMessage = null;
+
+            if (String.IsNullOrWhiteSpace(url))
+            {
+                errorMessage = "Value must not be null or empty";
+                return false;
+            }
+
+            if (!GitRemoteUrl.TryGetUri(url, out var uri))
+            {
+                errorMessage = $"Value '{url}' is not a valid uri";
+                return false;
+            }
+
+            switch (uri.Scheme.ToLower())
+            {
+                case "http":
+                case "https":
+                case "ssh":
+                    var projectPath = uri.AbsolutePath.Trim('/');
+                    projectPath = projectPath.RemoveSuffix(".git");
+
+                    if (String.IsNullOrWhiteSpace(projectPath))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project path is empty";
+                        return false;
+                    }
+
+                    if (!projectPath.Contains("/"))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Invalid project path '{projectPath}'";
+                        return false;
+                    }
+
+                    var splitIndex = projectPath.LastIndexOf('/');
+                    var @namespace = projectPath.Substring(0, splitIndex);
+                    var projectName = projectPath.Substring(splitIndex);
+
+                    if (String.IsNullOrWhiteSpace(@namespace))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project namespace is empty";
+                        return false;
+                    }
+
+                    if (String.IsNullOrWhiteSpace(projectName))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project name is empty";
+                        return false;
+                    }
+
+                    projectInfo = new GitLabProjectInfo(uri.Host, @namespace, projectName);
+                    return true;
+
+                default:
+                    errorMessage = $"Cannot parse '{url}' as GitLab url: Unsupported scheme '{uri.Scheme}'";
+                    return false;
+            }
+        }
+    }
+}

--- a/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabUrlParser.RemoteUrl.cs
@@ -59,6 +59,14 @@ namespace Grynwald.SemanticUrlParser.GitLab
                 case "https":
                 case "ssh":
                     var projectPath = uri.AbsolutePath.Trim('/');
+
+                    if (!projectPath.EndsWith(".git"))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Expected url to end with '.git'";
+                        return false;
+
+                    }
+
                     projectPath = projectPath.RemoveSuffix(".git");
 
                     if (String.IsNullOrWhiteSpace(projectPath))
@@ -74,8 +82,8 @@ namespace Grynwald.SemanticUrlParser.GitLab
                     }
 
                     var splitIndex = projectPath.LastIndexOf('/');
-                    var @namespace = projectPath.Substring(0, splitIndex);
-                    var projectName = projectPath.Substring(splitIndex);
+                    var @namespace = projectPath.Substring(0, splitIndex).Trim('/');
+                    var projectName = projectPath.Substring(splitIndex).Trim('/');
 
                     if (String.IsNullOrWhiteSpace(@namespace))
                     {

--- a/src/SemanticUrlParser/GitLab/GitLabUrlParser.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabUrlParser.cs
@@ -1,87 +1,9 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
-using Grynwald.SemanticUrlParser.Utilities;
-
-namespace Grynwald.SemanticUrlParser.GitLab.GitLab
+﻿namespace Grynwald.SemanticUrlParser.GitLab
 {
-    public static class GitLabUrlParser
+    /// <summary>
+    /// Parser for GitHub urls.
+    /// </summary>
+    public partial class GitLabUrlParser
     {
-        public static GitLabProjectInfo ParseRemoteUrl(string url)
-        {
-            if (TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
-            {
-                return projectInfo;
-            }
-            else
-            {
-                throw new ArgumentException(errorMessage, nameof(url));
-            }
-        }
-
-        public static bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo) =>
-            TryParseRemoteUrl(url, out projectInfo, out var _);
-
-
-        private static bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo, [NotNullWhen(false)] out string? errorMessage)
-        {
-            projectInfo = null;
-            errorMessage = null;
-
-            if (String.IsNullOrWhiteSpace(url))
-            {
-                errorMessage = "Value must not be null or empty";
-                return false;
-            }
-
-            if (!GitRemoteUrl.TryGetUri(url, out var uri))
-            {
-                errorMessage = $"Value '{url}' is not a valid uri";
-                return false;
-            }
-
-            switch (uri.Scheme.ToLower())
-            {
-                case "http":
-                case "https":
-                case "ssh":
-                    var projectPath = uri.AbsolutePath.Trim('/');
-                    projectPath = projectPath.RemoveSuffix(".git");
-
-                    if (String.IsNullOrWhiteSpace(projectPath))
-                    {
-                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project path is empty";
-                        return false;
-                    }
-
-                    if (!projectPath.Contains('/'))
-                    {
-                        errorMessage = $"Cannot parse '{url}' as GitLab url: Invalid project path '{projectPath}'";
-                        return false;
-                    }
-
-                    var splitIndex = projectPath.LastIndexOf('/');
-                    var @namespace = projectPath.Substring(0, splitIndex);
-                    var projectName = projectPath.Substring(splitIndex);
-
-                    if (String.IsNullOrWhiteSpace(@namespace))
-                    {
-                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project namespace is empty";
-                        return false;
-                    }
-
-                    if (String.IsNullOrWhiteSpace(projectName))
-                    {
-                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project name is empty";
-                        return false;
-                    }
-
-                    projectInfo = new GitLabProjectInfo(uri.Host, @namespace, projectName);
-                    return true;
-
-                default:
-                    errorMessage = $"Cannot parse '{url}' as GitLab url: Unsupported scheme '{uri.Scheme}'";
-                    return false;
-            }
-        }
     }
 }

--- a/src/SemanticUrlParser/GitLab/GitLabUrlParser.cs
+++ b/src/SemanticUrlParser/GitLab/GitLabUrlParser.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Grynwald.SemanticUrlParser.Utilities;
+
+namespace Grynwald.SemanticUrlParser.GitLab.GitLab
+{
+    public static class GitLabUrlParser
+    {
+        public static GitLabProjectInfo ParseRemoteUrl(string url)
+        {
+            if (TryParseRemoteUrl(url, out var projectInfo, out var errorMessage))
+            {
+                return projectInfo;
+            }
+            else
+            {
+                throw new ArgumentException(errorMessage, nameof(url));
+            }
+        }
+
+        public static bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo) =>
+            TryParseRemoteUrl(url, out projectInfo, out var _);
+
+
+        private static bool TryParseRemoteUrl(string url, [NotNullWhen(true)] out GitLabProjectInfo? projectInfo, [NotNullWhen(false)] out string? errorMessage)
+        {
+            projectInfo = null;
+            errorMessage = null;
+
+            if (String.IsNullOrWhiteSpace(url))
+            {
+                errorMessage = "Value must not be null or empty";
+                return false;
+            }
+
+            if (!GitRemoteUrl.TryGetUri(url, out var uri))
+            {
+                errorMessage = $"Value '{url}' is not a valid uri";
+                return false;
+            }
+
+            switch (uri.Scheme.ToLower())
+            {
+                case "http":
+                case "https":
+                case "ssh":
+                    var projectPath = uri.AbsolutePath.Trim('/');
+                    projectPath = projectPath.RemoveSuffix(".git");
+
+                    if (String.IsNullOrWhiteSpace(projectPath))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project path is empty";
+                        return false;
+                    }
+
+                    if (!projectPath.Contains('/'))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Invalid project path '{projectPath}'";
+                        return false;
+                    }
+
+                    var splitIndex = projectPath.LastIndexOf('/');
+                    var @namespace = projectPath.Substring(0, splitIndex);
+                    var projectName = projectPath.Substring(splitIndex);
+
+                    if (String.IsNullOrWhiteSpace(@namespace))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project namespace is empty";
+                        return false;
+                    }
+
+                    if (String.IsNullOrWhiteSpace(projectName))
+                    {
+                        errorMessage = $"Cannot parse '{url}' as GitLab url: Project name is empty";
+                        return false;
+                    }
+
+                    projectInfo = new GitLabProjectInfo(uri.Host, @namespace, projectName);
+                    return true;
+
+                default:
+                    errorMessage = $"Cannot parse '{url}' as GitLab url: Unsupported scheme '{uri.Scheme}'";
+                    return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for parsing GitLab remote urls with support for both HTTP and SSH urls.